### PR TITLE
Add encoding option for windows

### DIFF
--- a/gimei/gimei.py
+++ b/gimei/gimei.py
@@ -35,7 +35,7 @@ def yaml_load(file_path, mode='r'):
     import os
     file_dir = os.path.abspath(os.path.join(os.path.dirname(__file__)))
     try:
-        f = open(file_dir + '/' + file_path, mode)
+        f = open(file_dir + '/' + file_path, mode, encoding='utf-8')
     except IOError:
         raise Exception("Can not open {}".format(file_dir + '/' + file_path))
     return yaml.load(f, Loader=Loader)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-with open("README.rst",  "rt") as f: readme = f.read()
+with open("README.rst",  "rt", encoding="utf-8") as f: readme = f.read()
 
 
 setup(


### PR DESCRIPTION
Python in windows always expects shift-jis file as its input. This causes erros in installation of this usuful module via pip and in import.
By addind encoding options, it successes.


Windowsのpythonではファイル読み込み時にshift-jisエンコーディングが期待されるため、pipインストールやモジュールの使用時にエラーが出て失敗していました。
このエラーを回避するためにencodingオプションをつけました。