### PR TITLE
fix Address.__repr__(), Address.__str__()

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ print(name.first.katakana) # ヒトセ
 
 address = Gimei().address
 
-# print(address)             # (未実装) 大分県三潴郡大木町小原西 
+print(address)             # 大分県三潴郡大木町小原西 
 print(address.kanji)       # 大分県三潴郡大木町小原西
 print(address.hiragana)    # おおいたけんみずまぐんおおきまちこばらにし
 print(address.katakana)    # オオイタケンミズマグンオオキマチコバラニシ

--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ Usage
 
    address = Gimei().address
 
-   # print(address)             # (未実装) 大分県三潴郡大木町小原西 
+   print(address)             # 大分県三潴郡大木町小原西 
    print(address.kanji)       # 大分県三潴郡大木町小原西
    print(address.hiragana)    # おおいたけんみずまぐんおおきまちこばらにし
    print(address.katakana)    # オオイタケンミズマグンオオキマチコバラニシ

--- a/gimei/address.py
+++ b/gimei/address.py
@@ -108,8 +108,12 @@ class Address(object):
             self.town.katakana,
         )
 
+    def __str__(self):
+        return self.kanji
+
     def __repr__(self):
-        return self.kanji.encode('utf-8')
+        return "Address(prefecture={}, city={}, town={})".format(
+            self.prefecture.prefectures, self.city.cities, self.town.towns)
 
     @classmethod
     def get_prefectures(cls):

--- a/tests/test_address.py
+++ b/tests/test_address.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+import pytest
 from gimei import Gimei
 from gimei import Address
 
@@ -14,3 +15,18 @@ class TestAddress(object):
     def test_katakana_address_in_data(self):
         address = Gimei().address
         assert Address.find_address_by_katakana(address.katakana)
+
+
+@pytest.fixture
+def address():
+    address = Gimei().address
+    address.prefecture.prefectures = ['徳島県', 'とくしまけん', 'トクシマケン']
+    address.city.cities = ['徳島市', 'とくしまし', 'トクシマシ']
+    address.town.towns = ['万代町', 'ばんだいちょう', 'バンダイチョウ']
+    return address
+
+def test_str(address):
+    assert str(address) == '徳島県徳島市万代町'
+
+def test_repr(address):
+    assert repr(address) == "Address(prefecture=['徳島県', 'とくしまけん', 'トクシマケン'], city=['徳島市', 'とくしまし', 'トクシマシ'], town=['万代町', 'ばんだいちょう', 'バンダイチョウ'])"

--- a/tests/test_name.py
+++ b/tests/test_name.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+import pytest
 from gimei import Gimei
 from gimei import Name
 
@@ -16,19 +17,6 @@ class TestName(object):
         name = Gimei().name
         assert Name.find_name_by_katakana(name.katakana)
 
-    def test_str(self):
-        name = Gimei().name
-        name.first.all = ['糸央', 'いお', 'イオ']
-        name.last.all  = ['大木', 'おおき', 'オオキ']
-        assert str(name) == '大木 糸央'
-
-    def test_repr(self):
-        name = Gimei().name
-        name.gender    = 'female'
-        name.first.all = ['七祐', 'なゆ', 'ナユ']
-        name.last.all  = ['佐野', 'さの', 'サノ']
-        assert repr(name) == "Name(gender='female', first=['七祐', 'なゆ', 'ナユ'], last=['佐野', 'さの', 'サノ'])"
-
     def test_create_name_from_gender(self):
         name = Gimei('male').name
         assert name.is_male
@@ -36,3 +24,18 @@ class TestName(object):
     def test_create_name_from_gender(self):
         name = Gimei('female').name
         assert name.is_female
+
+
+@pytest.fixture
+def name():
+    name = Gimei().name
+    name.gender    = 'female'    
+    name.first.all = ['七祐', 'なゆ', 'ナユ']
+    name.last.all  = ['佐野', 'さの', 'サノ']
+    return name
+
+def test_str(name):
+    assert str(name) == '佐野 七祐'
+
+def test_repr(name):
+    assert repr(name) == "Name(gender='female', first=['七祐', 'なゆ', 'ナユ'], last=['佐野', 'さの', 'サノ'])"


### PR DESCRIPTION
`Address.__repr__()` と `Address.__str__()` に対しての変更。

Name に対して #7 と #9 でマージした同様の内容となってます。

該当する部分のテストと、README の更新を含みます。

さらに、#7, #9 で導入された Nameのテスト部分も、Address の該当するテストと同様に pytest.fixture を利用して重複部分を削除するように変更しました。
